### PR TITLE
chore: fixes dependabot and makes lint run on merge_group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
 version: 2
 updates:
-  - package-ecosystem: pnpm
+  - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     commit-message:
       prefix: fix
       prefix-development: chore

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: "Code lint"
 
-on: ["push"]
+on:
+  pull_request:
+  merge_group:
+  push:
 
 jobs:
   clean:


### PR DESCRIPTION
## What does this PR do?

This fixes `package-ecosystem` and `interval` in the `dependabot.yml` file.

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements).
