### PR TITLE
chore: add ignore and groups to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
       prefix: fix
       prefix-development: chore
       include: scope
+    ignore:
+      - dependency-name: '\*'
+        update-types: ["version-update:semver-patch"]
+    groups:
+      prod-dependencies:
+        dependency-type: "production"
+      dev-dependencies:
+        dependency-type: "development"


### PR DESCRIPTION
## What does this PR do?

Makes `dependabot` less spammy, ignore patch versions, and groups PRs in one.

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements).
